### PR TITLE
Wallet performance increased by removing excess logs

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -1038,7 +1038,6 @@ namespace cryptonote
             outamounts.push_back(amount_in - amount_out);
 
           if (tx_params.burn_fixed) {
-              LOG_PRINT_L2("burn_fixed");
               if (amount_in < amount_out + tx_params.burn_fixed) {
                   LOG_ERROR("invalid burn amount: tx does not have enough unspent funds available; amount_in: "
                                     << std::to_string(amount_in) << "; amount_out + tx_params.burn_fixed: "

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2645,8 +2645,7 @@ skip:
   template<class t_core>
   bool t_cryptonote_protocol_handler<t_core>::relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg, cryptonote_connection_context& exclude_context)
   {
-
-    LOG_PRINT_L2("relay_transactions");
+    MTRACE("relay_transactions");
     for(auto& tx_blob : arg.txs)
       m_core.on_transaction_relayed(tx_blob);
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5711,11 +5711,9 @@ bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_in
   if (ptx_vector.empty())
     return false;
 
-  LOG_PRINT_L0("confirm_and_send_tx");
   // if more than one tx necessary, prompt user to confirm
   if (m_wallet->always_confirm_transfers() || ptx_vector.size() > 1)
   {
-      LOG_PRINT_L0("confirm_and_send_tx 2");
       uint64_t total_sent = 0;
       uint64_t total_fee = 0;
       uint64_t dust_not_in_fee = 0;
@@ -5870,7 +5868,6 @@ bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_in
   }
   else
   {
-    LOG_PRINT_L0("confirm_and_send_tx commit_or_save");
     commit_or_save(ptx_vector, m_do_not_relay, flash);
   }
 
@@ -5880,10 +5877,9 @@ bool simple_wallet::confirm_and_send_tx(std::vector<cryptonote::address_parse_in
 //  "transfer [index=<N1>[,<N2>,...]] [<priority>] <address> <amount> [<payment_id>]"
 bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std::string> &args_, bool called_by_mms)
 {
-  LOG_PRINT_L0("transfer_main");
   if (!try_connect_to_daemon())
     return false;
-  LOG_PRINT_L0("connected to daemon");
+
   std::vector<std::string> local_args = args_;
 
   static constexpr auto BURN_PREFIX = "burn="sv;
@@ -5896,13 +5892,12 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
 
   uint32_t priority = 0;
   std::set<uint32_t> subaddr_indices  = {};
-  LOG_PRINT_L0("parse_subaddr_indices_and_priority..");
+
   if (!parse_subaddr_indices_and_priority(*m_wallet, local_args, subaddr_indices, priority, m_current_subaddress_account)) return false;
 
 
   if (priority == 0)
   {
-    LOG_PRINT_L0("priority == 0");
     priority = m_wallet->get_default_priority();
     if (priority == 0)
       priority = transfer_type == Transfer::Locked ? tools::tx_priority_unimportant : tools::tx_priority_flash;
@@ -5940,7 +5935,6 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
     }
     local_args.pop_back();
   }
-  LOG_PRINT_L0("payment_id_seen");
   bool payment_id_seen = false;
   std::vector<cryptonote::address_parse_info> dsts_info;
   std::vector<cryptonote::tx_destination_entry> dsts;
@@ -5996,7 +5990,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
     de.is_subaddress = info.is_subaddress;
     de.is_integrated = info.has_payment_id;
     num_subaddresses += info.is_subaddress;
-    LOG_PRINT_L0("check has_payment_id" );
+
     if (info.has_payment_id || !payment_id_uri.empty())
     {
       if (payment_id_seen)
@@ -6031,7 +6025,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
 
     dsts.push_back(de);
   }
-  LOG_PRINT_L0("before try step" );
+
   SCOPED_WALLET_UNLOCK_ON_BAD_PASSWORD(return false;);
 
   try
@@ -6042,7 +6036,6 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
     std::string err;
     if (transfer_type == Transfer::Locked)
     {
-        LOG_PRINT_L0("Locked type" );
       bc_height = get_daemon_blockchain_height(err);
       if (!err.empty())
       {
@@ -6058,12 +6051,8 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
       fail_msg_writer() << tools::ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
       return false;
     }
-    LOG_PRINT_L0("get_hard_fork_version" << *hf_version );
 
-    LOG_PRINT_L0("construct_params" );
     beldex_construct_tx_params tx_params = tools::wallet2::construct_params(*hf_version, txtype::standard, priority, burn_amount);
-    LOG_PRINT_L0("construct_params:" );
-      LOG_PRINT_L0("create_transactions_2:" );
     ptx_vector = m_wallet->create_transactions_2(dsts, CRYPTONOTE_DEFAULT_TX_MIXIN, unlock_block, priority, extra, m_current_subaddress_account, subaddr_indices, tx_params);
 
     if (ptx_vector.empty())
@@ -6071,7 +6060,7 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
       fail_msg_writer() << tr("No outputs found, or daemon is not ready");
       return false;
     }
-      LOG_PRINT_L0("confirm_and_send_tx:" );
+
     if (!confirm_and_send_tx(dsts_info, ptx_vector, priority == tools::tx_priority_flash, locked_blocks, unlock_block, called_by_mms))
       return false;
   }

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -101,21 +101,18 @@ void NodeRPCProxy::set_height(uint64_t h)
 bool NodeRPCProxy::get_info() const
 {
   if (m_offline) return false;
-  LOG_PRINT_L0("get_info");
   auto now = std::chrono::steady_clock::now();
   if (now >= m_get_info_time + 30s) // re-cache every 30 seconds
   {
     try {
       auto resp_t = invoke_json_rpc<rpc::GET_INFO>({});
       m_height = resp_t.height;
-      LOG_PRINT_L0("GET_INFO success" << m_height);
       m_target_height = resp_t.target_height;
       m_block_weight_limit = resp_t.block_weight_limit ? resp_t.block_weight_limit : resp_t.block_size_limit;
       m_immutable_height = resp_t.immutable_height;
       m_get_info_time = now;
       m_height_time = now;
     } catch (...) {
-        LOG_PRINT_L0("GET_INFO failed");
         return false; }
   }
   return true;
@@ -123,12 +120,10 @@ bool NodeRPCProxy::get_info() const
 
 bool NodeRPCProxy::get_height(uint64_t &height) const
 {
-  LOG_PRINT_L0("NodeRPCProxy::get_height");
   auto now = std::chrono::steady_clock::now();
   if (now >= m_height_time + 30s) // re-cache every 30 seconds
     if (!get_info())
       return false;
-  LOG_PRINT_L0("NodeRPCProxy::get_height:" << m_height);
   height = m_height;
   return true;
 }
@@ -161,35 +156,29 @@ bool NodeRPCProxy::get_earliest_height(uint8_t version, uint64_t &earliest_heigh
 {
   if (m_offline)
     return false;
-  LOG_PRINT_L0("get_earliest_height");
+
   if (m_earliest_height[version] == 0)
   {
     rpc::HARD_FORK_INFO::request req_t{};
     req_t.version = version;
     try {
-      LOG_PRINT_L0("get_earliest_height invoke json HARD_FORK_INFO");
       auto resp_t = invoke_json_rpc<rpc::HARD_FORK_INFO>(req_t);
 
-      if (!resp_t.earliest_height) {
-          LOG_PRINT_L0("resp_t get_earliest_height earliest_height is NULL" );
-          return false;
-      }
-      LOG_PRINT_L0("resp_t get_earliest_height invoke json HARD_FORK_INFO" << *resp_t.earliest_height);
+      if (!resp_t.earliest_height)
+        return false;
+
       m_earliest_height[version] = *resp_t.earliest_height;
     } catch (...) { return false; }
   }
-    LOG_PRINT_L0("resp_t get_earliest_height version" << version );
   earliest_height = m_earliest_height[version];
-  LOG_PRINT_L0("resp_t get_earliest_height earliest_height" << earliest_height );
   return true;
 }
 
 std::optional<uint8_t> NodeRPCProxy::get_hardfork_version() const
 {
-    LOG_PRINT_L0("get_hardfork_version");
     if (m_offline)
        return std::nullopt;
-    LOG_PRINT_L0("invoke HARD_FORK_INFO");
+
     auto now = std::chrono::steady_clock::now();
     if (now >= m_hardfork_version_time + 30s) // re-cache every 30 seconds
     {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7771,18 +7771,18 @@ uint64_t wallet2::get_fee_percent(uint32_t priority, txtype type) const
   static constexpr std::array<uint64_t, 4> percents{{100, 500, 2500, 12500}};
 
   const bool flashable = type == txtype::standard;
-  LOG_PRINT_L2("get_fee_percent:" << priority);
+
   if (priority == 0) // 0 means no explicit priority was given, so use the wallet default
   {
     priority = m_default_priority > 0 ? m_default_priority : (uint32_t) tx_priority_flash;
     if (priority == tx_priority_flash && !flashable)
       priority = tx_priority_unimportant; // The flash default is unusable for this tx, so fall back to unimportant
   }
-  LOG_PRINT_L2("get_fee_percent after:" << priority);
+
   // If it's a flashable tx then we flash it for everything priority other than unimportant.
   if (flashable && priority != tx_priority_unimportant)
     priority = tx_priority_flash;
-  LOG_PRINT_L2("get_fee_percent after2:" << priority);
+
   if (priority == tx_priority_flash)
   {
     if (!flashable)
@@ -7806,7 +7806,6 @@ uint64_t wallet2::get_fee_percent(uint32_t priority, txtype type) const
 byte_and_output_fees wallet2::get_dynamic_base_fee_estimate() const
 {
   byte_and_output_fees fees;
-  LOG_PRINT_L2("get_dynamic_base_fee_estimate");
   if (m_node_rpc_proxy.get_dynamic_base_fee_estimate(FEE_ESTIMATE_GRACE_BLOCKS, fees))
     return fees;
 
@@ -10864,7 +10863,6 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
 
   if(m_light_wallet) {
     // Populate m_transfers
-      LOG_PRINT_L0("m_light_wallet" );
     light_wallet_get_unspent_outs();
   }
   std::vector<std::pair<uint32_t, std::vector<size_t>>> unused_transfers_indices_per_subaddr;
@@ -10872,7 +10870,6 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   uint64_t needed_money;
   uint64_t accumulated_fee, accumulated_outputs, accumulated_change;
 
-    LOG_PRINT_L0("creating struct TX" );
   struct TX {
     std::vector<size_t> selected_transfers;
     std::vector<cryptonote::tx_destination_entry> dsts;
@@ -10882,12 +10879,9 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
     uint64_t needed_fee;
     std::vector<std::vector<tools::wallet2::get_outs_entry>> outs;
 
-    TX() : weight(0), needed_fee(0) {
-        LOG_PRINT_L0("TX struct initiated" );
-    }
+    TX() : weight(0), needed_fee(0) {}
 
     void add(const cryptonote::tx_destination_entry &de, uint64_t amount, unsigned int original_output_index, bool merge_destinations) {
-        LOG_PRINT_L0("struct ADD" );
       if (merge_destinations)
       {
         std::vector<cryptonote::tx_destination_entry>::iterator i;
@@ -10914,22 +10908,16 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       }
     }
   };
-  LOG_PRINT_L0("creating the TX vector" );
   std::vector<TX> txes;
 
   bool adding_fee; // true if new outputs go towards fee, rather than destinations
   uint64_t needed_fee, available_for_fee = 0;
-    LOG_PRINT_L0("get_upper_transaction_weight_limit" );
   uint64_t upper_transaction_weight_limit = get_upper_transaction_weight_limit();
   const bool clsag = use_fork_rules(HF_VERSION_CLSAG, 0);
-  LOG_PRINT_L0("clsag: << clsag");
   const rct::RCTConfig rct_config{rct::RangeProofType::PaddedBulletproof, clsag ? 3 : 2};
-    LOG_PRINT_L0("get_base_fees" );
   const auto base_fee = get_base_fees();
-    LOG_PRINT_L0("get_fee_percent" );
   const uint64_t fee_percent = get_fee_percent(priority, tx_params.tx_type);
   uint64_t fixed_fee = 0;
-    LOG_PRINT_L0("get_fee_quantization_mask" );
   const uint64_t fee_quantization_mask = get_fee_quantization_mask();
 
   uint64_t burn_fixed = 0, burn_percent = 0;
@@ -10960,7 +10948,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   {
     THROW_WALLET_EXCEPTION_IF(0 == dt.amount && !is_bns_tx, error::zero_destination);
     needed_money += dt.amount;
-    LOG_PRINT_L0("transfer: adding " << print_money(dt.amount) << ", for a total of " << print_money (needed_money));
+    LOG_PRINT_L2("transfer: adding " << print_money(dt.amount) << ", for a total of " << print_money (needed_money));
     THROW_WALLET_EXCEPTION_IF(needed_money < dt.amount, error::tx_sum_overflow, dsts, 0, m_nettype);
   }
 
@@ -11021,7 +11009,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
     {
       if (td.amount() > m_ignore_outputs_above || td.amount() < m_ignore_outputs_below)
       {
-        LOG_PRINT_L0("Ignoring output " << i << " of amount " << print_money(td.amount()) << " which is outside prescribed range [" << print_money(m_ignore_outputs_below) << ", " << print_money(m_ignore_outputs_above) << "]");
+        MDEBUG("Ignoring output " << i << " of amount " << print_money(td.amount()) << " which is outside prescribed range [" << print_money(m_ignore_outputs_below) << ", " << print_money(m_ignore_outputs_above) << "]");
         continue;
       }
       const uint32_t index_minor = td.m_subaddr_index.minor;
@@ -11090,7 +11078,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   // this prevents linking to another by provenance analysis, but two is ok if we
   // try to pick outputs not from the same block. We will get two outputs, one for
   // the destination, and one for change.
-  LOG_PRINT_L0("checking preferred");
+  LOG_PRINT_L2("checking preferred");
   std::vector<size_t> preferred_inputs;
   uint64_t rct_outs_needed = 2 * (fake_outs_count + 1);
   rct_outs_needed += 100; // some fudge factor since we don't know how many are locked
@@ -11872,16 +11860,11 @@ void wallet2::get_hard_fork_info(uint8_t version, uint64_t &earliest_height) con
 bool wallet2::use_fork_rules(uint8_t version, uint64_t early_blocks) const
 {
   // TODO: How to get fork rule info from light wallet node?
-  LOG_PRINT_L2("use_fork_rules");
     if(m_light_wallet)
     return true;
   uint64_t height, earliest_height{0};
-  LOG_PRINT_L2("get_height:" << height);
   if (!m_node_rpc_proxy.get_height(height))
     THROW_WALLET_EXCEPTION(tools::error::no_connection_to_daemon, __func__);
-
-    LOG_PRINT_L2("get_earliest_height requesting for version :" << version);
-    LOG_PRINT_L2("get_earliest_height:" << earliest_height);
 
   if (!m_node_rpc_proxy.get_earliest_height(version, earliest_height))
     THROW_WALLET_EXCEPTION(tools::error::no_connection_to_daemon, __func__);
@@ -11889,7 +11872,7 @@ bool wallet2::use_fork_rules(uint8_t version, uint64_t early_blocks) const
   bool close_enough = height >= earliest_height - early_blocks; // start using the rules that many blocks beforehand
   if (early_blocks > earliest_height) // Start using rules early if early_blocks would underflow earliest_height, in prev calc
     close_enough = true;
-  LOG_PRINT_L2("close_enough:" << close_enough);
+
   if (close_enough)
     LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
   else


### PR DESCRIPTION
The wallet CLI is taking too much time to load a wallet. This issue happens because of more logs in the node_rpc_proxy.cpp and wallet2.cpp this are removed in this commit

