### PR TITLE
Bump version V5.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ nbproject
 /testnet
 
 __pycache__/
+
+# brew build lock file
+contrib/brew/Brewfile.lock.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,9 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(beldex
-    VERSION 4.1.0
+    VERSION 5.0.0
     LANGUAGES CXX C)
-set(BELDEX_RELEASE_CODENAME "Bucephalus")
+set(BELDEX_RELEASE_CODENAME "Bern")
 
 # String value to append to the full version string; this is intended to easily identify whether a
 # binary was build from the release or development branches.  This should be permanently set to an

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ breakdown of the minimum set of required boost packages.
 Install all dependencies at once on Debian/Ubuntu:
 
 ```
-sudo apt update && sudo apt install build-essential cmake pkg-config libboost-all-dev libzmq3-dev libsodium-dev libunwind8-dev liblzma-dev libreadline6-dev doxygen graphviz libpgm-dev libsqlite3-dev libcurl4-dev
+sudo apt update && sudo apt install build-essential cmake pkg-config libboost-all-dev libzmq3-dev libsodium-dev libunwind8-dev liblzma-dev libreadline6-dev doxygen graphviz libpgm-dev libsqlite3-dev curl
 ```
 
 Install all dependencies at once on macOS with the provided Brewfile:

--- a/src/cryptonote_core/master_node_rules.h
+++ b/src/cryptonote_core/master_node_rules.h
@@ -233,9 +233,8 @@ namespace master_nodes {
     std::array<uint16_t, 3> storage_server;
   };
 
-  //TODO bns-rework have to give the new versions
   constexpr proof_version MIN_UPTIME_PROOF_VERSIONS[] = {
-    proof_version{{cryptonote::network_version_18_bns, 0}, {4,0,0}, {0,9,5}, {2,2,0}},
+    proof_version{{cryptonote::network_version_18_bns, 0}, {5,0,0}, {0,9,7}, {2,3,0}},
     proof_version{{cryptonote::network_version_17_POS, 0}, {4,0,0}, {0,9,5}, {2,2,0}},
     proof_version{{cryptonote::network_version_16, 0}, {4,0,0}, {0,9,5}, {2,2,0}},
     proof_version{{cryptonote::network_version_15_flash, 0}, {4,0,0}, {0,9,5}, {2,2,0}},


### PR DESCRIPTION
Added support for the new hard fork version **'Bern'**.