### PR TITLE
Drop locked_key_image support as it's not required currently

### DIFF
--- a/src/lws/src/db/data.cpp
+++ b/src/lws/src/db/data.cpp
@@ -105,7 +105,6 @@ namespace db
       wire::field("timestamp", self.timestamp),
       wire::field("tx_hash", std::cref(self.link.tx_hash)),
       wire::field("tx_prefix_hash", std::cref(self.tx_prefix_hash)),
-      wire::field("locked_key_image", std::cref(self.locked_key_image)),
       wire::field("tx_public", std::cref(self.spend_meta.tx_public)),
       wire::optional_field("rct_mask", rct_mask),
       wire::optional_field("payment_id", payment_id),

--- a/src/lws/src/db/data.h
+++ b/src/lws/src/db/data.h
@@ -158,7 +158,6 @@ namespace db
     std::uint64_t timestamp;
     std::uint64_t unlock_time; //!< Not always a timestamp; mirrors chain value.
     crypto::hash tx_prefix_hash;
-    crypto::key_image locked_key_image;
     crypto::public_key pub;    //!< One-time spendable public key.
     rct::key ringct_mask;      //!< Unencrypted CT mask
     char reserved[7];
@@ -169,7 +168,7 @@ namespace db
       crypto::hash long_;    //!< Long version of payment id (always decrypted)
     } payment_id;
   };
-  static_assert(sizeof(output) == 8 + 32 + (8 * 3) + (4 * 2) + 32 + (8 * 2) + (32 * 4) + 7 + 1 + 32, "padding in output");
+  static_assert(sizeof(output) == 8 + 32 + (8 * 3) + (4 * 2) + 32 + (8 * 2) + (32 * 3) + 7 + 1 + 32, "padding in output");
   void write_bytes(wire::writer&, const output&);
 
   //! Information about a possible spend of a received `output`.

--- a/src/lws/src/rpc/light_wallet.cpp
+++ b/src/lws/src/rpc/light_wallet.cpp
@@ -101,7 +101,6 @@ namespace
       wire::field("tx_id", self.data.first.spend_meta.id.low),
       wire::field("tx_hash", std::cref(self.data.first.link.tx_hash)),
       wire::field("tx_prefix_hash", std::cref(self.data.first.tx_prefix_hash)),
-      wire::field("locked_key_image", std::cref(self.data.first.locked_key_image)),
       wire::field("tx_pub_key", self.data.first.spend_meta.tx_public),
       wire::field("timestamp", iso_timestamp(self.data.first.timestamp)),
       wire::field("height", self.data.first.link.height),

--- a/src/lws/src/scanner.cpp
+++ b/src/lws/src/scanner.cpp
@@ -97,8 +97,6 @@ namespace lws
       cryptonote::transaction const& tx,
       std::vector<std::uint64_t> const& out_ids)
     {
-      boost::optional<crypto::key_image> locked_key_image;
-
       if (cryptonote::txversion::v4_tx_types < tx.version)
         throw std::runtime_error{"Unsupported tx version"};
 
@@ -130,18 +128,6 @@ namespace lws
         else
           extra_nonce = boost::none;
       } // destruct `extra` vector
-
-      {
-
-        cryptonote::tx_extra_tx_key_image_proofs key_image_proofs;
-        get_field_from_tx_extra(tx.extra, key_image_proofs);
-
-        if (!key_image_proofs.proofs.empty())
-        {
-          // Assign the key_image from the first proof to locked_key_image
-          locked_key_image = key_image_proofs.proofs.front().key_image;
-        }
-      }
 
       for (account &user : users)
       {
@@ -260,7 +246,6 @@ namespace lws
                   timestamp,
                   tx.unlock_time,
                   *prefix_hash,
-                  locked_key_image ? *locked_key_image : crypto::key_image{},
                   out_data->key,
                   mask,
                   {0, 0, 0, 0, 0, 0, 0}, // reserved bytes


### PR DESCRIPTION
- Removed the locked_key_image field from the output structure.
- Cleaned up all serialization/deserialization logic referencing the field.
- Updated LMDB reading/writing logic accordingly.
- Removed any processing, validation, or matching logic tied to locked_key_image.
- Adjusted static assertions and size checks impacted by the structure change.
- Cleaned up any unused helper functions or variables related to this field.