### PR TITLE
fix(uptime_proof): validate version-list sizes before fixed-array writes

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1991,7 +1991,16 @@ namespace cryptonote
   bool core::handle_btencoded_uptime_proof(const NOTIFY_BTENCODED_UPTIME_PROOF::request &req, bool &my_uptime_proof_confirmation)
   {
     crypto::x25519_public_key pkey = {};
-    auto proof = std::make_unique<uptime_proof::Proof>(req.proof);
+    std::unique_ptr<uptime_proof::Proof> proof;
+    try
+    {
+      proof = std::make_unique<uptime_proof::Proof>(req.proof);
+    }
+    catch (const std::exception &e)
+    {
+      MWARNING("Failed to parse uptime proof: " << e.what());
+      return false;
+    }
     proof->sig = tools::make_from_guts<crypto::signature>(req.sig);
     proof->sig_ed25519 = tools::make_from_guts<crypto::ed25519_signature>(req.ed_sig);
     auto pubkey = proof->pubkey;

--- a/src/cryptonote_core/uptime_proof.cpp
+++ b/src/cryptonote_core/uptime_proof.cpp
@@ -49,6 +49,8 @@ Proof::Proof(const std::string& serialized_proof)
     const bt_dict bt_proof = bt_deserialize<bt_dict>(serialized_proof);
     //mnode_version <X,X,X>
     const bt_list& bt_version = var::get<bt_list>(bt_proof.at("v"));
+    if (bt_version.size() != version.size())
+      throw std::invalid_argument("uptime proof: invalid mnode_version list size");
     int k = 0;
     for (bt_value const &i: bt_version){
       version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));
@@ -72,12 +74,16 @@ Proof::Proof(const std::string& serialized_proof)
     storage_omq_port = get_int<unsigned>(bt_proof.at("sop"));
     //storage_version
     const bt_list& bt_storage_version = var::get<bt_list>(bt_proof.at("sv"));
+    if (bt_storage_version.size() != storage_server_version.size())
+      throw std::invalid_argument("uptime proof: invalid storage_version list size");
     k = 0;
     for (bt_value const &i: bt_storage_version){
       storage_server_version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));
     }
     //belnet_version
     const bt_list& bt_belnet_version = var::get<bt_list>(bt_proof.at("lv"));
+    if (bt_belnet_version.size() != belnet_version.size())
+      throw std::invalid_argument("uptime proof: invalid belnet_version list size");
     k = 0;
     for (bt_value const &i: bt_belnet_version){
       belnet_version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));


### PR DESCRIPTION
The `Proof::Proof(const std::string& serialized_proof)` deserializer at `src/cryptonote_core/uptime_proof.cpp:44-89` reads three version lists (`v`, `sv`, `lv`) from a bt-encoded peer-supplied blob into three fixed-size 3-element arrays (`version[]`, `storage_server_version[]`, `belnet_version[]`) without first checking that each bt_list has 3 entries:

```cpp
const bt_list& bt_version = var::get<bt_list>(bt_proof.at("v"));
int k = 0;
for (bt_value const &i: bt_version){
  version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));
}
```

A peer that sends a proof whose `v` list has more than 3 entries walks past the end of `version[]` into adjacent members of the `Proof` struct on the heap (the constructor is invoked via `std::make_unique` at `cryptonote_core.cpp:1994`). The constructor runs before any signature check downstream.

Patch adds an exact-size guard before each write loop, and wraps the `make_unique` call site in try/catch so a malformed proof becomes a rejected proof rather than a propagating exception:

```diff
     const bt_list& bt_version = var::get<bt_list>(bt_proof.at("v"));
+    if (bt_version.size() != version.size())
+      throw std::invalid_argument("uptime proof: invalid mnode_version list size");
     int k = 0;
     for (bt_value const &i: bt_version){
       version[k++] = static_cast<uint16_t>(get_int<unsigned>(i));
     }
```

(Plus matching guards for `sv` and `lv`.)

```diff
   bool core::handle_btencoded_uptime_proof(...)
   {
     crypto::x25519_public_key pkey = {};
-    auto proof = std::make_unique<uptime_proof::Proof>(req.proof);
+    std::unique_ptr<uptime_proof::Proof> proof;
+    try
+    {
+      proof = std::make_unique<uptime_proof::Proof>(req.proof);
+    }
+    catch (const std::exception &e)
+    {
+      MWARNING("Failed to parse uptime proof: " << e.what());
+      return false;
+    }
     proof->sig = tools::make_from_guts<crypto::signature>(req.sig);
```

Exact-match (`!=`) rather than `>` because a short list would leave the trailing array slots uninitialized.
