### PR TITLE
fix(tx_extra): enforce equal vector lengths in tx_extra_master_node_register

### DIFF
--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -330,6 +330,13 @@ namespace cryptonote
       FIELD(m_portions)
       FIELD(m_expiration_timestamp)
       FIELD(m_master_node_signature)
+      if (Archive::is_deserializer)
+      {
+        if (m_public_spend_keys.size() != m_public_view_keys.size())
+          throw std::invalid_argument{"tx_extra_master_node_register: spend/view key count mismatch"};
+        if (m_public_spend_keys.size() != m_portions.size())
+          throw std::invalid_argument{"tx_extra_master_node_register: spend/portions count mismatch"};
+      }
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_core/master_node_list.cpp
+++ b/src/cryptonote_core/master_node_list.cpp
@@ -301,6 +301,9 @@ namespace master_nodes
     if (!cryptonote::get_master_node_pubkey_from_tx_extra(tx.extra, master_node_key))
       return false;
 
+    if (registration.m_public_spend_keys.size() != registration.m_public_view_keys.size()
+        || registration.m_public_spend_keys.size() != registration.m_portions.size())
+      return false;
     contributor_args.addresses.clear();
     contributor_args.addresses.reserve(registration.m_public_spend_keys.size());
     for (size_t i = 0; i < registration.m_public_spend_keys.size(); i++) {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -710,9 +710,13 @@ namespace cryptonote::rpc {
       void operator()(const tx_extra_security_signature& x) { set("security_sig", tools::type_to_hex(x.m_security_signature)); }
       void operator()(const tx_extra_master_node_register& x) {
         json reservations{};
-        for (size_t i = 0; i < x.m_portions.size(); i++)
-          reservations[get_account_address_as_str(nettype, false, {x.m_public_spend_keys[i], x.m_public_view_keys[i]})]
-            = microportion(x.m_portions[i]);
+        if (x.m_public_spend_keys.size() == x.m_public_view_keys.size()
+            && x.m_public_spend_keys.size() == x.m_portions.size())
+        {
+          for (size_t i = 0; i < x.m_portions.size(); i++)
+            reservations[get_account_address_as_str(nettype, false, {x.m_public_spend_keys[i], x.m_public_view_keys[i]})]
+              = microportion(x.m_portions[i]);
+        }
         set("mn_registration", json{
           {"fee", microportion(x.m_portions_for_operator)},
           {"expiry", x.m_expiration_timestamp},


### PR DESCRIPTION
`tx_extra_master_node_register` at `src/cryptonote_basic/tx_extra.h:317-334` carries three parallel vectors (`m_public_spend_keys`, `m_public_view_keys`, `m_portions`) that are intended to be index-aligned. The serializer reads each as an independent vector with no cross-field invariant, so a malformed field with desynchronized lengths deserializes successfully and exposes consumers to out-of-bounds reads.

Two consumers index by one vectors size and read another. The block-include path at `master_node_list.cpp:305-309` (`reg_tx_extract_fields`):

```cpp
for (size_t i = 0; i < registration.m_public_spend_keys.size(); i++) {
  contributor_args.addresses.back().m_view_public_key = registration.m_public_view_keys[i];
}
```

`validate_contributor_args` (line 333) catches the size mismatch only after the loop runs.

The RPC path at `core_rpc_server.cpp:711-720` (`extra_extractor::operator()(tx_extra_master_node_register&)`) is reachable from any otherwise valid relayable transaction that carries a malformed `tx_extra_master_node_register` field. `tx_pool::add_tx` accepts arbitrary `tx.extra` content on standard transfer transactions, so the tx sits in mempool until a caller queries `get_transactions` or `get_transaction_pool` with `tx_extra=true`. The visitor then reads past the end of one of the key vectors; outcome depends on heap layout.

Patch enforces the equal-length invariant at deserialization (matching the `tx_extra_padding` pattern at `tx_extra.h:195-210`), and adds size-equality guards at both consumers so the call sites stay safe if the invariant ever drifts.

```diff
   struct tx_extra_master_node_register
   {
     ...
     BEGIN_SERIALIZE()
       FIELD(m_public_spend_keys)
       FIELD(m_public_view_keys)
       FIELD(m_portions_for_operator)
       FIELD(m_portions)
       FIELD(m_expiration_timestamp)
       FIELD(m_master_node_signature)
+      if (Archive::is_deserializer)
+      {
+        if (m_public_spend_keys.size() != m_public_view_keys.size())
+          throw std::invalid_argument{"tx_extra_master_node_register: spend/view key count mismatch"};
+        if (m_public_spend_keys.size() != m_portions.size())
+          throw std::invalid_argument{"tx_extra_master_node_register: spend/portions count mismatch"};
+      }
     END_SERIALIZE()
   };
```
