### PR TITLE
fix(tx_pool): dedupe key-image conflict list; make remove_tx idempotent

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -758,7 +758,25 @@ namespace cryptonote
     {
       if (!stc_it)
       {
-        MWARNING("remove_tx: tx " << txid << " not in sorted container, treating as already-removed");
+        // Not in the sorted container. Usually fully removed, but a tx can be sorted-erased while
+        // still present in the backing store (DB row, key images, counted weight). Check the backend
+        // before returning success so we don't leave orphaned key images behind.
+        txpool_tx_meta_t orphan_meta;
+        if (!m_blockchain.get_txpool_tx_meta(txid, orphan_meta))
+        {
+          MWARNING("remove_tx: tx " << txid << " not in sorted container or backend, treating as already-removed");
+          return true;
+        }
+        cryptonote::blobdata orphan_blob = m_blockchain.get_txpool_tx_blob(txid);
+        cryptonote::transaction_prefix orphan_tx;
+        if (!parse_and_validate_tx_prefix_from_blob(orphan_blob, orphan_tx))
+        {
+          MERROR("remove_tx: tx " << txid << " present in backend but unparseable; leaving for manual cleanup");
+          return false;
+        }
+        m_blockchain.remove_txpool_tx(txid);
+        m_txpool_weight -= orphan_meta.weight;
+        remove_transaction_keyimages(orphan_tx, txid);
         return true;
       }
       MERROR("Failed to find tx in txpool sorted list");

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -756,6 +756,11 @@ namespace cryptonote
     const auto it = stc_it ? *stc_it : find_tx_in_sorted_container(txid);
     if (it == m_txs_by_fee_and_receive_time.end())
     {
+      if (!stc_it)
+      {
+        MWARNING("remove_tx: tx " << txid << " not in sorted container, treating as already-removed");
+        return true;
+      }
       MERROR("Failed to find tx in txpool sorted list");
       return false;
     }
@@ -1449,6 +1454,7 @@ namespace cryptonote
     auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);
 
     bool ret = false;
+    std::unordered_set<crypto::hash> seen;
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, txin_to_key, tokey_in, true);//should never fail
@@ -1458,7 +1464,9 @@ namespace cryptonote
         if (!conflicting)
           return true;
         ret = true;
-        conflicting->insert(conflicting->end(), it->second.begin(), it->second.end());
+        for (const auto &h : it->second)
+          if (seen.insert(h).second)
+            conflicting->push_back(h);
       }
     }
     return ret;


### PR DESCRIPTION
`tx_memory_pool::have_tx_keyimges_as_spent` at `src/cryptonote_core/tx_pool.cpp:1447-1465` appends every conflicting txid into the `conflicting` vector per spent key image, with no dedupe. If one mempool tx shares two or more key images with the incoming tx, its txid is appended multiple times.

The approved-flash path in `tx_pool::add_tx` (`tx_pool.cpp:361-365`) calls `remove_flash_conflicts` (which starts at `tx_pool.cpp:674`). `remove_flash_conflicts` iterates that vector and calls `remove_tx` per entry. The first call succeeds; the second call on the same txid fails at the sorted-container check at line 760. `remove_flash_conflicts` treats the failure as a hard error and returns early, so the `LockedTXN` destructor aborts the DB batch. The LMDB row is restored, but the in-memory mutations from the first call (`m_txpool_weight` decrement at line 787, `remove_transaction_keyimages` at line 788, sorted-container erase at line 789) are not rolled back. `m_spent_key_images` then no longer contains entries for that txs inputs, so a subsequent tx spending the same outputs is not rejected by `have_tx_keyimges_as_spent` until the orphaned row is aged out or the daemon restarts.

This is reachable when a single signer produces two transactions sharing 2+ key images (a normal mempool tx and an approved flash tx for the same inputs).

Patch dedupes the conflict list at source via `unordered_set`, and makes `remove_tx` idempotent for ad-hoc callers that pass `stc_it = nullptr` (with an MWARNING log so the path stays observable):

```diff
   bool tx_memory_pool::have_tx_keyimges_as_spent(const transaction& tx, std::vector<crypto::hash> *conflicting) const
   {
     auto locks = tools::unique_locks(m_transactions_lock, m_blockchain);

     bool ret = false;
+    std::unordered_set<crypto::hash> seen;
     for(const auto& in: tx.vin)
     {
       CHECKED_GET_SPECIFIC_VARIANT(in, txin_to_key, tokey_in, true);
       auto it = m_spent_key_images.find(tokey_in.k_image);
       if (it != m_spent_key_images.end())
       {
         if (!conflicting)
           return true;
         ret = true;
-        conflicting->insert(conflicting->end(), it->second.begin(), it->second.end());
+        for (const auto &h : it->second)
+          if (seen.insert(h).second)
+            conflicting->push_back(h);
       }
     }
     return ret;
   }
```

```diff
     const auto it = stc_it ? *stc_it : find_tx_in_sorted_container(txid);
     if (it == m_txs_by_fee_and_receive_time.end())
     {
+      if (!stc_it)
+      {
+        MWARNING("remove_tx: tx " << txid << " not in sorted container, treating as already-removed");
+        return true;
+      }
       MERROR("Failed to find tx in txpool sorted list");
       return false;
     }
```

The bool-only fast path of `have_tx_keyimges_as_spent` (`conflicting == nullptr`) is unchanged. The pruner at line 794 passes a known-good `stc_it` and keeps the loud-fail semantics.
