### PR TITLE
wallet2: fix malformed get_transactions params in pool tx fetch

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3377,7 +3377,7 @@ std::vector<wallet2::get_pool_state_tx> wallet2::get_pool_state(bool refreshed)
 
     try {
       nlohmann::json get_transactions_params{
-        {{"txs_hashes", hex_hashes}},
+        {"txs_hashes", hex_hashes},
         {"prune",true},
         {"split",true},
         {"data",true}


### PR DESCRIPTION
The txs_hashes field in the get_transactions RPC parameters was wrapped in an extra pair of braces ({{"txs_hashes", hex_hashes}}), making it one level deeper than the other object members. This caused nlohmann::json to serialize the parameters incorrectly, so the daemon rejected every pool transaction request with "Invalid params" ("Failed to retrieve transactions" in the wallet log), preventing wallet synchronization.