### PR TITLE
Fix POS round state logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ message(STATUS "CMake version ${CMAKE_VERSION}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "macOS deployment target (Apple clang only)")
 
 project(beldex
-    VERSION 7.0.2
+    VERSION 7.0.3
     LANGUAGES CXX C)
 set(BELDEX_RELEASE_CODENAME "Obscura")
 

--- a/src/cryptonote_core/pos.cpp
+++ b/src/cryptonote_core/pos.cpp
@@ -1044,13 +1044,27 @@ round_state goto_wait_for_next_block_and_clear_round_data(round_context &context
   return round_state::wait_for_next_block;
 }
 
+// Returns true if the blockchain's top block differs from the tip cached in
+// the round context — either because a new block arrived (height changed) or
+// because a same-height reorg replaced the top block (hash changed at the
+// same height).
+static bool chain_top_changed(round_context const &context, cryptonote::Blockchain const &blockchain)
+{
+  uint64_t const chain_height = blockchain.get_current_blockchain_height(true /*lock*/);
+  if (context.wait_for_next_block.height != chain_height)
+    return true;
+  return context.wait_for_next_block.top_hash != blockchain.get_block_id_by_height(chain_height - 1);
+}
+
 round_state wait_for_next_block(uint64_t hf17_height, round_context &context, cryptonote::Blockchain const &blockchain)
 {
   //
-  // NOTE: If already processing POS for height, wait for next height
+  // NOTE: If already processing POS for height, wait for next height. The top 
+  // hash is compared too (not just the height) so that a same-height reorg
+  // re-arms the round context against the new tip
   //
   uint64_t chain_height = blockchain.get_current_blockchain_height(true /*lock*/);
-  if (context.wait_for_next_block.height == chain_height)
+  if (!chain_top_changed(context, blockchain))
   {
     for (static uint64_t last_height = 0; last_height != chain_height; last_height = chain_height)
       MDEBUG(log_prefix(context) << "Network is currently producing block " << chain_height << ", waiting until next block");
@@ -1119,9 +1133,9 @@ round_state prepare_for_round(round_context &context, master_nodes::master_node_
       return goto_wait_for_next_block_and_clear_round_data(context);
     }
 
-    // Also check if the blockchain has changed, in which case we stop and
-    // restart POS stages.
-    if (context.wait_for_next_block.height != blockchain.get_current_blockchain_height(true /*lock*/))
+    // Also check if the blockchain has changed (new block, or same-height
+    // reorg), in which case we stop and restart POS stages.
+    if (chain_top_changed(context, blockchain))
       return goto_wait_for_next_block_and_clear_round_data(context);
 
     // 'queue_for_next_round' is set when an intermediate POS stage has failed
@@ -1161,6 +1175,11 @@ round_state prepare_for_round(round_context &context, master_nodes::master_node_
   }
 
   std::vector<crypto::hash> const entropy = master_nodes::get_POS_entropy_for_next_block(blockchain.get_db(), context.wait_for_next_block.top_hash, context.prepare_for_round.round);
+  if (entropy.empty())
+  {
+    MDEBUG(log_prefix(context) << "Unable to prepare POS quorum for height " << context.wait_for_next_block.height << " because quorum entropy is unavailable; waiting for the next block");
+    return goto_wait_for_next_block_and_clear_round_data(context);
+  }
   auto const active_node_list             = blockchain.get_master_node_list().active_master_nodes_infos();
   auto hf_version                         = blockchain.get_network_version();
   crypto::public_key const &block_leader  = blockchain.get_master_node_list().get_block_leader().key;
@@ -1212,10 +1231,9 @@ round_state prepare_for_round(round_context &context, master_nodes::master_node_
 
 round_state wait_for_round(round_context &context, cryptonote::Blockchain const &blockchain)
 {
-  const auto curr_height = blockchain.get_current_blockchain_height(true /*lock*/);
-  if (context.wait_for_next_block.height != curr_height)
+  if (chain_top_changed(context, blockchain))
   {
-    MTRACE(log_prefix(context) << "Block height changed whilst waiting for round " << +context.prepare_for_round.round << ", restarting POS stages");
+    MTRACE(log_prefix(context) << "Chain tip changed whilst waiting for round " << +context.prepare_for_round.round << ", restarting POS stages");
     return goto_wait_for_next_block_and_clear_round_data(context);
   }
 
@@ -1231,7 +1249,7 @@ round_state wait_for_round(round_context &context, cryptonote::Blockchain const 
   // For testing purposes: we apply possible random non-response and random delays to half of all
   // blocks; we go in batches of 10: 10 maybe-faulty blocks followed by 10 well-behaved blocks.
   // (Faulty blocks have an odd second-last height digit).
-  if (curr_height % 20 >= 10)
+  if (context.wait_for_next_block.height % 20 >= 10)
   {
     size_t faulty_chance = tools::uniform_distribution_portable(tools::rng, 100);
     if (faulty_chance < 10)

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -593,11 +593,11 @@ namespace nodetool
     }
     else
     {
-      full_addrs.insert("seed1.beldex.io:19090");
+      full_addrs.insert("seed1.rpcnode.stream:19090");
       full_addrs.insert("seed2.rpcnode.stream:19090");
-      full_addrs.insert("seed3.beldex.io:19090");
+      full_addrs.insert("seed3.rpcnode.stream:19090");
       full_addrs.insert("seed4.rpcnode.stream:19090");
-      full_addrs.insert("seed5.beldex.io:19090");
+      full_addrs.insert("seed5.rpcnode.stream:19090");
     }
     return full_addrs;
   }


### PR DESCRIPTION
The POS state machine previously detected staleness by comparing
heights only. An equal-height fork switch (pop block N, adopt the competing
block N) leaves the chain height unchanged, so the state machine kept using
`wait_for_next_block.top_hash`, which by then referred to a block deleted
from both the main and the alt DB (switch_to_alternative_blockchain() is
called with keep_disconnected_chain=false on the POS weight/checkpoint
reorg paths). The next entropy lookup then failed with:
     "Failed to find block <hash>"
     "Failed to get quorum entropy for POS, next block parent <hash>"
and the node sat out POS participation until the next height. Comparing the
top hash as well restarts the POS stages against the new tip immediately.