### PR TITLE
fix: stuck flash height tracking and silent exclusive-node fallback

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -449,6 +449,7 @@ namespace cryptonote
         if (it != our_flash_hashes.end() && it->second == hash)
         { // Matches our hash already, great
           context.m_flash_state.erase(height);
+          context.m_flash_heights_requested.erase(height);
           continue;
         }
 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -2344,6 +2344,12 @@ namespace nodetool
       std::vector<epee::net_utils::network_address> resolved_addrs;
       bool r = append_net_address(resolved_addrs, pr_str, default_port, m_use_ipv6);
       CHECK_AND_ASSERT_MES(r, false, "Failed to parse or resolve address from string: " << pr_str);
+      if (resolved_addrs.empty() && std::string_view{arg.name} == arg_p2p_add_exclusive_node.name)
+      {
+        CHECK_AND_ASSERT_MES(false, false,
+            "Exclusive peer resolved but yielded no usable addresses: " << pr_str
+            << " (for example, all results may be IPv6 while IPv6 is disabled)");
+      }
       for (const epee::net_utils::network_address& addr : resolved_addrs)
       {
         container.push_back(addr);


### PR DESCRIPTION
A height erased from m_flash_state on a matching advertisement kept its entry in m_flash_heights_requested. If the peer later advertised a new checksum, the height was re-added through the "not found" branch, which does not clear the requested set, so the build loop skipped it and it was never re-requested.