### PR TITLE
Persist the master node list periodically so an unclean exit doesn't cost the database

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -322,7 +322,10 @@ bool Blockchain::load_missing_blocks_into_beldex_subsystems()
 
   using clock                   = std::chrono::steady_clock;
   using dseconds                = std::chrono::duration<double>;
-  int64_t constexpr BLOCK_COUNT = 1000;
+  // Chunk size for the rescan. Since the transactions of a whole chunk are now parsed up front and
+  // held at once (rather than one block at a time), this bounds the peak allocation of the scan --
+  // it matters on memory-capped nodes. oxen-core uses 50 for the same reason.
+  int64_t constexpr BLOCK_COUNT = 200;
   auto work_start               = clock::now();
   auto scan_start               = work_start;
   dseconds bns_duration{}, mnl_duration{}, bns_iteration_duration{}, mnl_iteration_duration{}, tx_load_duration{}, tx_load_total{};

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -376,7 +376,7 @@ bool Blockchain::load_missing_blocks_into_beldex_subsystems()
         try {
           m_master_node_list.block_add(blk, txs, checkpoint_ptr);
         } catch (const std::exception& e) {
-          MFATAL("Unable to process block {} for updating master node list: " << e.what());
+          MFATAL("Unable to process block " << cryptonote::get_block_hash(blk) << " at height " << block_height << " for updating master node list: " << e.what());
           return false;
         }
         mnl_iteration_duration += clock::now() - mnl_start;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -53,6 +53,9 @@
 #include "epee/int-util.h"
 #include "epee/time_helper.h"
 #include "epee/string_tools.h"
+#include <atomic>
+#include <limits>
+
 #include "common/threadpool.h"
 #include "common/boost_serialization_helper.h"
 #include "epee/warnings.h"
@@ -302,6 +305,11 @@ uint64_t Blockchain::get_current_blockchain_height(bool lock) const
 //------------------------------------------------------------------
 bool Blockchain::load_missing_blocks_into_beldex_subsystems()
 {
+  // Held for the whole scan: the tx deserialisation below runs on the thread pool and uses the
+  // non-locking _get_transactions, which requires that nothing mutates the chain meanwhile.
+  // m_blockchain_lock is recursive, so this is safe when a caller already holds it.
+  std::unique_lock lock{*this};
+
   uint64_t const mnl_height   = std::max(hard_fork_begins(m_nettype, hf::hf9_master_nodes).value_or(0), m_master_node_list.height() + 1);
   uint64_t const bns_height   = std::max(hard_fork_begins(m_nettype, hf::hf18_bns).value_or(0), m_bns_db.height() + 1);
   uint64_t const end_height   = m_db->height();
@@ -317,7 +325,7 @@ bool Blockchain::load_missing_blocks_into_beldex_subsystems()
   int64_t constexpr BLOCK_COUNT = 1000;
   auto work_start               = clock::now();
   auto scan_start               = work_start;
-  dseconds bns_duration{}, mnl_duration{}, bns_iteration_duration{}, mnl_iteration_duration{};
+  dseconds bns_duration{}, mnl_duration{}, bns_iteration_duration{}, mnl_iteration_duration{}, tx_load_duration{}, tx_load_total{};
 
   for (int64_t block_count = total_blocks,
                index       = 0;
@@ -328,11 +336,12 @@ bool Blockchain::load_missing_blocks_into_beldex_subsystems()
     if (duration >= 10s)
     {
       m_master_node_list.store();
-      MGINFO(fmt::format("... scanning height {} ({:.3f}s) (mnl: {:.3f}s, bns: {:.3f}s)",
+      MGINFO(fmt::format("... scanning height {} ({:.3f}s) (mnl: {:.3f}s, bns: {:.3f}s, txs: {:.3f}s)",
             start_height + (index * BLOCK_COUNT),
             duration.count(),
             mnl_iteration_duration.count(),
-            bns_iteration_duration.count()));
+            bns_iteration_duration.count(),
+            tx_load_duration.count()));
 #ifdef ENABLE_SYSTEMD
       // Tell systemd that we're doing something so that it should let us continue starting up
       // (giving us 120s until we have to send the next notification):
@@ -342,7 +351,7 @@ bool Blockchain::load_missing_blocks_into_beldex_subsystems()
 
       bns_duration += bns_iteration_duration;
       mnl_duration += mnl_iteration_duration;
-      bns_iteration_duration = mnl_iteration_duration = {};
+      bns_iteration_duration = mnl_iteration_duration = tx_load_duration = {};
     }
 
     std::vector<cryptonote::block> blocks;
@@ -353,16 +362,50 @@ bool Blockchain::load_missing_blocks_into_beldex_subsystems()
       return false;
     }
 
-    for (cryptonote::block const &blk : blocks)
+    // Deserialising the transactions for a chunk dominates the scan and is independent per block,
+    // so do it across the thread pool while the subsystem updates below stay strictly sequential.
+    // _get_transactions is the non-locking form: we already hold the blockchain lock for the whole
+    // scan, and LMDB hands each thread its own read transaction.
+    std::vector<std::vector<cryptonote::transaction>> chunk_txs(blocks.size());
     {
-      uint64_t block_height = get_block_height(blk);
-
-      std::vector<cryptonote::transaction> txs;
-      if (!get_transactions(blk.tx_hashes, txs))
+      auto tx_load_start = clock::now();
+      // Record which block failed, not just that one did: this aborts daemon startup, and the
+      // block identity is what tells an operator whether they are looking at a pruned or a
+      // corrupted database. Workers race to claim the slot; the lowest index wins so the message
+      // names the earliest failure rather than whichever thread finished first.
+      constexpr size_t NO_FAILURE = std::numeric_limits<size_t>::max();
+      std::atomic<size_t> failed_index{NO_FAILURE};
+      tools::threadpool& tpool = tools::threadpool::getInstance();
+      tools::threadpool::waiter waiter;
+      for (size_t blk_index = 0; blk_index < blocks.size(); blk_index++)
       {
-        MERROR("Unable to get transactions for block for updating BNS DB: " << cryptonote::get_block_hash(blk));
+        tpool.submit(&waiter, [this, blk_index, &blocks, &chunk_txs, &failed_index]() {
+          if (_get_transactions(blocks[blk_index].tx_hashes, chunk_txs[blk_index]))
+            return;
+          size_t previous = failed_index.load(std::memory_order_relaxed);
+          while (blk_index < previous &&
+                 !failed_index.compare_exchange_weak(previous, blk_index, std::memory_order_relaxed))
+            ; // retry: another worker claimed it first
+        });
+      }
+      waiter.wait(&tpool);
+      if (size_t failed = failed_index.load(); failed != NO_FAILURE)
+      {
+        cryptonote::block const &blk = blocks[failed];
+        MERROR("Unable to get transactions for block " << cryptonote::get_block_hash(blk)
+               << " at height " << get_block_height(blk) << " while updating beldex subsystems");
         return false;
       }
+      auto tx_load_elapsed = dseconds{clock::now() - tx_load_start};
+      tx_load_duration += tx_load_elapsed;
+      tx_load_total    += tx_load_elapsed;
+    }
+
+    for (size_t blk_index = 0; blk_index < blocks.size(); blk_index++)
+    {
+      cryptonote::block const &blk = blocks[blk_index];
+      uint64_t block_height = get_block_height(blk);
+      std::vector<cryptonote::transaction> &txs = chunk_txs[blk_index];
 
       if (block_height >= mnl_height)
       {
@@ -397,8 +440,8 @@ bool Blockchain::load_missing_blocks_into_beldex_subsystems()
 
   if (total_blocks > 1)
   {
-    MGINFO(fmt::format("Done recalculating beldex subsystems in {:.2f}s ({:.2f}s mnl; {:.2f}s bns)",
-          dseconds{clock::now() - scan_start}.count(), mnl_duration.count(), bns_duration.count()));
+    MGINFO(fmt::format("Done recalculating beldex subsystems in {:.2f}s ({:.2f}s mnl; {:.2f}s bns; {:.2f}s tx load)",
+          dseconds{clock::now() - scan_start}.count(), mnl_duration.count(), bns_duration.count(), tx_load_total.count()));
   }
 
   if (total_blocks > 0)
@@ -2731,7 +2774,15 @@ bool Blockchain::get_transactions(const std::vector<crypto::hash>& txs_ids, std:
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   std::unique_lock lock{*this};
-
+  return _get_transactions(txs_ids, txs, missed_txs);
+}
+//------------------------------------------------------------------
+// Non-locking version of get_transactions. The caller must already hold the blockchain lock (or
+// otherwise guarantee that nothing is mutating the chain). This exists so that transactions can be
+// deserialised from several threads at once during a subsystem rescan: the LMDB layer gives each
+// thread its own read transaction, but taking the blockchain lock per call would serialise them.
+bool Blockchain::_get_transactions(const std::vector<crypto::hash>& txs_ids, std::vector<transaction>& txs, std::unordered_set<crypto::hash>* missed_txs) const
+{
   txs.reserve(txs_ids.size());
   cryptonote::blobdata tx;
   for (const auto& tx_hash : txs_ids)

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -743,6 +743,7 @@ namespace cryptonote
     bool get_split_transactions_blobs(const std::vector<crypto::hash>& txs_ids, std::vector<std::tuple<crypto::hash, cryptonote::blobdata, crypto::hash, cryptonote::blobdata>>& txs, std::unordered_set<crypto::hash>* missed_txs = nullptr) const;
     bool get_transactions(const std::vector<crypto::hash>& txs_ids, std::vector<transaction>& txs, std::unordered_set<crypto::hash>* missed_txs = nullptr) const;
 
+
     /**
      * @brief looks up transactions based on a list of transaction hashes and returns the block
      * height in which they were mined, or 0 if not found on the blockchain.
@@ -1032,6 +1033,15 @@ namespace cryptonote
 
 #ifndef IN_UNIT_TESTS
   private:
+
+    /**
+     * @brief Non-locking form of get_transactions.
+     *
+     * The caller must already hold the blockchain lock. Private on purpose: a non-locking accessor
+     * is easy to call from the wrong place, and the locking get_transactions() is the entry point
+     * everything outside Blockchain should use.
+     */
+    bool _get_transactions(const std::vector<crypto::hash>& txs_ids, std::vector<transaction>& txs, std::unordered_set<crypto::hash>* missed_txs = nullptr) const;
 #endif
 
     struct block_pow_verified

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2431,6 +2431,7 @@ namespace cryptonote
     m_check_disk_space_interval.do_call([this] { return check_disk_space(); });
     m_block_rate_interval.do_call([this] { return check_block_rate(); });
     m_mn_proof_cleanup_interval.do_call([&mnl=m_master_node_list] { mnl.cleanup_proofs(); return true; });
+    m_mn_list_store_interval.do_call([&mnl=m_master_node_list] { mnl.checkpoint_state(); return true; });
 
     std::chrono::seconds lifetime{time(nullptr) - get_start_time()};
     if (m_master_node && lifetime > get_net_config().UPTIME_PROOF_STARTUP_DELAY) // Give us some time to connect to peers before sending uptimes

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1178,6 +1178,7 @@ namespace cryptonote
      tools::periodic_task m_blockchain_pruning_interval{5h}; //!< interval for incremental blockchain pruning
      tools::periodic_task m_master_node_vote_relayer{2min, false};
      tools::periodic_task m_mn_proof_cleanup_interval{1h, false};
+     tools::periodic_task m_mn_list_store_interval{5min, false}; //!< interval for checkpointing the master node list so an unclean exit doesn't force a full rescan
      tools::periodic_task m_systemd_notify_interval{10s};
 
      std::atomic<bool> m_starter_message_showed; //!< has the "daemon will sync now" message been shown?

--- a/src/cryptonote_core/master_node_list.cpp
+++ b/src/cryptonote_core/master_node_list.cpp
@@ -2729,40 +2729,49 @@ namespace master_nodes
       m_transient.cache_short_term_data.states.push_back(serialize_master_node_state_object(hf_version, *it, it->height < max_short_term_height /*only_serialize_quorums*/));
     }
 
-    m_transient.cache_data_blob.clear();
-    if (write_archive)
-    {
-      serialization::binary_string_archiver ba;
-      try {
-        serialization::serialize(ba, m_transient.cache_long_term_data);
-      } catch (const std::exception& e) {
-        LOG_ERROR("Failed to store master node info: failed to serialize long term data: " << e.what());
-        return false;
-      }
-      m_transient.cache_data_blob.append(ba.str());
+    // Serialise one cache and hand it to the DB. The archiver owns an ostringstream whose buffer is
+    // as large as the blob, so it is scoped to die before the write rather than being held alive
+    // beside a copy of itself; the blob is moved out rather than appended into a member that would
+    // keep its high-water capacity for the life of the process. On a large long-term archive each
+    // avoided copy is hundreds of MB, which is the difference between fitting in a small container
+    // and swapping.
+    auto write_cache = [this](data_for_serialization &cache, bool long_term, std::string_view what) {
+      auto started = std::chrono::steady_clock::now();
+      std::string blob;
       {
-        auto &db = m_blockchain.get_db();
-        cryptonote::db_wtxn_guard txn_guard{db};
-        db.set_master_node_data(m_transient.cache_data_blob, true /*long_term*/);
-      }
-    }
+        serialization::binary_string_archiver ba;
+        try {
+          serialization::serialize(ba, cache);
+        } catch (const std::exception& e) {
+          LOG_ERROR("Failed to store master node info: failed to serialize " << what << " data: " << e.what());
+          return false;
+        }
+        blob = ba.str();
+      } // archiver, and its copy of the bytes, released here
 
-    m_transient.cache_data_blob.clear();
-    {
-      serialization::binary_string_archiver ba;
-      try {
-        serialization::serialize(ba, m_transient.cache_short_term_data);
-      } catch (const std::exception& e) {
-        LOG_ERROR("Failed to store master node info: failed to serialize short term data: " << e.what());
-        return false;
-      }
-      m_transient.cache_data_blob.append(ba.str());
+      // The serialised objects are no longer needed; release them before the write so the peak is
+      // the blob alone rather than the blob plus everything it was built from.
+      cache.clear();
+      cache.states.shrink_to_fit();
+      cache.quorum_states.shrink_to_fit();
+
+      const size_t bytes = blob.size();
       {
         auto &db = m_blockchain.get_db();
         cryptonote::db_wtxn_guard txn_guard{db};
-        db.set_master_node_data(m_transient.cache_data_blob, false /*long_term*/);
+        db.set_master_node_data(blob, long_term);
       }
-    }
+      MGINFO(fmt::format("Stored {} master node data: {} in {:.2f}s", what,
+                         tools::get_human_readable_bytes(bytes),
+                         std::chrono::duration<double>{std::chrono::steady_clock::now() - started}.count()));
+      return true;
+    };
+
+    if (write_archive && !write_cache(m_transient.cache_long_term_data, true, "long term"))
+      return false;
+
+    if (!write_cache(m_transient.cache_short_term_data, false, "short term"))
+      return false;
 
     if (write_archive)
       m_transient.state_added_to_archive = false; // else stays dirty for the next full store()

--- a/src/cryptonote_core/master_node_list.cpp
+++ b/src/cryptonote_core/master_node_list.cpp
@@ -2748,6 +2748,7 @@ namespace master_nodes
     }
 
     m_transient.state_added_to_archive = false;
+    m_last_stored_height               = m_state.height;
     return true;
   }
 
@@ -3100,6 +3101,30 @@ namespace master_nodes
       x25519_pkey = derived_x25519_pubkey;
 
     return true;
+  }
+
+  // Persist the master node list if it has advanced since the last write. The list is otherwise
+  // only stored at the end of a rescan and in core::deinit(), so a daemon that dies without a clean
+  // shutdown (SIGKILL, OOM, power loss, an assertion failure) loses every block of state it
+  // accumulated while running. On the next launch load_missing_blocks_into_beldex_subsystems() then
+  // has to replay from wherever the last stored state left off, which for a long-running daemon
+  // means rescanning most of the chain -- slow, and able to fail outright, in which case the daemon
+  // cannot start at all. Checkpointing on a timer bounds that replay to a few blocks.
+  //
+  // Locks the blockchain as well as the list because this runs from the idle thread, off the block
+  // handling path, and store() opens its own write transaction (see cleanup_proofs, same pattern).
+  void master_node_list::checkpoint_state()
+  {
+    auto locks = tools::unique_locks(m_mn_mutex, m_blockchain);
+    if (m_state.height <= m_last_stored_height)
+      return; // Nothing new since the last write
+
+    uint64_t const height = m_state.height;
+    if (store())
+      MDEBUG("Checkpointed the master node list at height " << height);
+    else
+      MWARNING("Failed to checkpoint the master node list at height " << height
+               << "; an unclean shutdown will require a longer rescan on the next start");
   }
 
   void master_node_list::cleanup_proofs()
@@ -3525,6 +3550,7 @@ namespace master_nodes
 
     initialize_x25519_map();
 
+    m_last_stored_height = m_state.height;
     MGINFO("Master node data loaded successfully, height: " << m_state.height);
     MGINFO(m_state.master_nodes_infos.size()
            << " nodes and " << m_transient.state_history.size() << " recent states loaded, " << m_transient.state_archive.size()
@@ -3546,6 +3572,7 @@ namespace master_nodes
     }
 
     m_state.height = hard_fork_begins(m_blockchain.nettype(), hf::hf9_master_nodes).value_or(1) - 1;
+    m_last_stored_height = m_state.height;
   }
 
   size_t master_node_info::total_num_locked_contributions() const

--- a/src/cryptonote_core/master_node_list.cpp
+++ b/src/cryptonote_core/master_node_list.cpp
@@ -1500,7 +1500,7 @@ namespace master_nodes
 
       if (!quorum)
       {
-        throw std::runtime_error{fmt::format("Failed to get testing quorum checkpoint for {} {}", block_type, cryptonote::get_block_hash(block))};
+        throw std::runtime_error{fmt::format("Failed to get testing quorum checkpoint for {}{}", block_type, tools::type_to_hex(cryptonote::get_block_hash(block)))};
       }
 
       bool failed_checkpoint_verify = !master_nodes::verify_checkpoint(block.major_version, *checkpoint, *quorum);
@@ -1517,7 +1517,7 @@ namespace master_nodes
       }
 
       if (failed_checkpoint_verify)
-        throw std::runtime_error{fmt::format("Master node checkpoint failed verification for {} {}", block_type, cryptonote::get_block_hash(block))};
+        throw std::runtime_error{fmt::format("Master node checkpoint failed verification for {}{}", block_type, tools::type_to_hex(cryptonote::get_block_hash(block)))};
     }
 
     //
@@ -1533,7 +1533,7 @@ namespace master_nodes
         cryptonote::block prev_block;
         if (!find_block_in_db(m_blockchain.get_db(), block.prev_id, prev_block))
         {
-          throw std::runtime_error{fmt::format("Alt block {} references previous block {} not available in DB.",cryptonote::get_block_hash(block), block.prev_id)};
+          throw std::runtime_error{fmt::format("Alt block {} references previous block {} not available in DB.", tools::type_to_hex(cryptonote::get_block_hash(block)), tools::type_to_hex(block.prev_id))};
         }
 
         prev_timestamp = prev_block.timestamp;
@@ -1546,7 +1546,7 @@ namespace master_nodes
 
       if (!POS::get_round_timings(m_blockchain, height, prev_timestamp, timings))
       {
-        throw std::runtime_error{fmt::format("Failed to query the block data for POS timings to validate incoming {} at height {}",block_type, height)};
+        throw std::runtime_error{fmt::format("Failed to query the block data for POS timings to validate incoming {}{} at height {}", block_type, tools::type_to_hex(cryptonote::get_block_hash(block)), height)};
       }
     }
 
@@ -1606,7 +1606,7 @@ namespace master_nodes
     }
 
     if (!result)
-      throw std::runtime_error{fmt::format("Failed to verify block components for incoming {} at height {}",block_type, height)};
+      throw std::runtime_error{fmt::format("Failed to verify block components for incoming {}{} at height {}", block_type, tools::type_to_hex(cryptonote::get_block_hash(block)), height)};
   }
 
   void master_node_list::block_add(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs, cryptonote::checkpoint_t const *checkpoint)
@@ -2431,7 +2431,7 @@ namespace master_nodes
       quorum POS_quorum = generate_POS_quorum(m_blockchain.nettype(), block_leader.key, hf_version, m_state.active_master_nodes_infos(), entropy, block.POS.round);
       if (!verify_POS_quorum_sizes(POS_quorum))
       {
-        throw std::runtime_error{fmt::format("POS block received but POS has insufficient nodes for quorum, block hash {}, height {} " ,cryptonote::get_block_hash(block),height)};
+        throw std::runtime_error{fmt::format("POS block received but POS has insufficient nodes for quorum, block hash {}, height {} ", tools::type_to_hex(cryptonote::get_block_hash(block)), height)};
       }
 
       block_producer_key = POS_quorum.workers[0];
@@ -2620,7 +2620,7 @@ namespace master_nodes
 
     if (starting_state->block_hash != block.prev_id)
     {
-      throw std::runtime_error{fmt::format("Unexpected state_t's hash: {}, does not match the block prev hash: {}",starting_state->block_hash, block.prev_id)};
+      throw std::runtime_error{fmt::format("Unexpected state_t's hash: {}, does not match the block prev hash: {}", tools::type_to_hex(starting_state->block_hash), tools::type_to_hex(block.prev_id))};
     }
 
     // NOTE: Generate the next Master Node list state from this Alt block.
@@ -3353,6 +3353,7 @@ namespace master_nodes
     reset(false);
     if (!m_blockchain.has_db())
     {
+      LOG_PRINT_L0("Blockchain DB is not available, cannot load master node data");
       return false;
     }
 
@@ -3433,7 +3434,10 @@ namespace master_nodes
 
     // NOTE: Deserialize short term state history
     if (!db.get_master_node_data(blob, false))
+    {
+      LOG_PRINT_L0("No short term master node data stored in the DB, regenerating state");
       return false;
+    }
 
     bytes_loaded += blob.size();
     data_for_serialization data_in = {};
@@ -3445,7 +3449,10 @@ namespace master_nodes
     }
 
     if (data_in.states.empty())
+    {
+      LOG_PRINT_L0("Short term master node data in the DB contains no states, regenerating state");
       return false;
+    }
 
     {
       const uint64_t hist_state_from_height = current_height - m_store_quorum_history;

--- a/src/cryptonote_core/master_node_list.cpp
+++ b/src/cryptonote_core/master_node_list.cpp
@@ -2195,6 +2195,12 @@ namespace master_nodes
   {
     std::lock_guard lock(m_mn_mutex);
 
+    // We are about to move m_state backwards. Whatever is on disk was written for a chain that has
+    // now been rolled back -- possibly a different fork at the same height -- so clear the
+    // high-water mark, otherwise checkpoint_state()'s guard suppresses every write until the chain
+    // climbs back past it and the stale copy survives to be reloaded on the next start.
+    m_last_stored_height = 0;
+
     uint64_t revert_to_height = height - 1;
     bool reinitialise         = false;
     bool using_archive        = false;
@@ -2215,6 +2221,11 @@ namespace master_nodes
       {
         m_transient.state_history.clear();
         m_transient.state_archive.erase(std::next(it), m_transient.state_archive.end());
+        // The archive we just truncated is still on disk with the detached fork's tail attached.
+        // Mark it dirty so the next full store() rewrites it; otherwise the short-term record
+        // follows the new chain while the long-term record keeps states from the abandoned one,
+        // and load() restores that pair on the next start.
+        m_transient.state_added_to_archive = true;
         using_archive = true;
       }
     }
@@ -2666,7 +2677,7 @@ namespace master_nodes
     return result;
   }
 
-  bool master_node_list::store()
+  bool master_node_list::store(bool include_archive)
   {
     if (!m_blockchain.has_db())
         return false; // Haven't been initialized yet
@@ -2686,12 +2697,18 @@ namespace master_nodes
       serialize_entry->clear();
     }
 
+    // Serialising the long-term archive is the expensive half of this function: it grows without
+    // bound (hundreds of MB on mainnet) and the ostringstream/str()/append sequence transiently
+    // needs several times its size. The periodic checkpoint skips it and leaves the dirty flag set
+    // so the next full store() -- end of rescan, or shutdown -- writes it.
+    const bool write_archive = m_transient.state_added_to_archive && include_archive;
+
     m_transient.cache_short_term_data.quorum_states.reserve(m_transient.old_quorum_states.size());
     for (const quorums_by_height &entry : m_transient.old_quorum_states)
       m_transient.cache_short_term_data.quorum_states.push_back(serialize_quorum_state(hf_version, entry.height, entry.quorums));
 
 
-    if (m_transient.state_added_to_archive)
+    if (write_archive)
     {
       for (auto const &it : m_transient.state_archive)
         m_transient.cache_long_term_data.states.push_back(serialize_master_node_state_object(hf_version, it));
@@ -2713,7 +2730,7 @@ namespace master_nodes
     }
 
     m_transient.cache_data_blob.clear();
-    if (m_transient.state_added_to_archive)
+    if (write_archive)
     {
       serialization::binary_string_archiver ba;
       try {
@@ -2747,8 +2764,9 @@ namespace master_nodes
       }
     }
 
-    m_transient.state_added_to_archive = false;
-    m_last_stored_height               = m_state.height;
+    if (write_archive)
+      m_transient.state_added_to_archive = false; // else stays dirty for the next full store()
+    m_last_stored_height = m_state.height;
     return true;
   }
 
@@ -3120,7 +3138,7 @@ namespace master_nodes
       return; // Nothing new since the last write
 
     uint64_t const height = m_state.height;
-    if (store())
+    if (store(false /*include_archive*/))
       MDEBUG("Checkpointed the master node list at height " << height);
     else
       MWARNING("Failed to checkpoint the master node list at height " << height

--- a/src/cryptonote_core/master_node_list.h
+++ b/src/cryptonote_core/master_node_list.h
@@ -512,7 +512,11 @@ namespace master_nodes
 
     void set_my_master_node_keys(const master_node_keys *keys);
     void set_quorum_history_storage(uint64_t hist_size); // 0 = none (default), 1 = unlimited, N = # of blocks
-    bool store();
+    /// Persist the master node list. When include_archive is false only the bounded short-term blob
+    /// is written and the long-term archive stays dirty for the next full store(); serialising the
+    /// archive costs minutes and several hundred MB of transient allocation once it has grown, so
+    /// the periodic checkpoint must not pay it.
+    bool store(bool include_archive = true);
 
     //TODO: remove after HF18
     crypto::hash hash_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof) const;

--- a/src/cryptonote_core/master_node_list.h
+++ b/src/cryptonote_core/master_node_list.h
@@ -536,6 +536,10 @@ namespace master_nodes
     // Called every hour to remove proofs for expired MNs from memory and the database.
     void cleanup_proofs();
 
+    /// Write the master node list out if it has advanced since the last store. Called periodically
+    /// from core::on_idle so that an unclean shutdown does not force a full rescan on next start.
+    void checkpoint_state();
+
     // Called via RPC from storage server/belnet to report a ping test result for a remote storage
     // server/belnet.
     //
@@ -712,6 +716,10 @@ namespace master_nodes
     cryptonote::Blockchain&       m_blockchain;
     const master_node_keys      *m_master_node_keys;
     uint64_t                      m_store_quorum_history = 0;
+    // Height at which the master node list was last persisted to the DB. Used to periodically
+    // checkpoint state while at the chain tip so that an unclean exit only costs a short replay
+    // instead of a full rescan from the hf9 height.
+    uint64_t                      m_last_stored_height = 0;
     mutable std::shared_mutex     m_x25519_map_mutex;
 
     /// Maps x25519 pubkeys to registration pubkeys + last block seen value (used for expiry)

--- a/src/cryptonote_core/master_node_list.h
+++ b/src/cryptonote_core/master_node_list.h
@@ -748,7 +748,6 @@ namespace master_nodes
       bool                                      state_added_to_archive;
       data_for_serialization                    cache_long_term_data;
       data_for_serialization                    cache_short_term_data;
-      std::string                               cache_data_blob;
     } m_transient = {};
 
     state_t m_state; // NOTE: Not in m_transient due to the non-trivial constructor. We can't blanket initialise using = {}; needs to be reset in ::reset(...) manually


### PR DESCRIPTION
A master node that exits uncleanly loses its master node list and cannot always rebuild it, which costs the operator the whole database. These five commits address that, plus the logging that made it hard to diagnose.

Found while running a large fleet of master nodes in memory-capped containers, where unclean exits (OOM kills, crashes) are the normal way a node stops.

## The problem

`master_node_list::store()` is only called at the end of a subsystem rescan and in `core::deinit()`. A daemon following the chain tip therefore never writes the list out until it is asked to shut down cleanly. Any unclean exit discards every block of state accumulated since the process started.

On the next launch `load_missing_blocks_into_beldex_subsystems()` replays from wherever the last stored state left off. For a long-running daemon that is most of the chain — slow, and able to fail outright:

```
ERROR  master_nodes  master_node_list.cpp:649  Could not get a quorum that could completely validate the block
FATAL  blockchain    blockchain.cpp:379        Unable to process block {} for updating master node list: ...
FATAL  daemon        daemon.cpp:386            Failed to start core
```

It does not self-heal — each restart re-scans from the hf9 height and fails at the same block.

## The fix

`checkpoint_state()` writes the list from `core::on_idle` at most every five minutes, and only when it has advanced. That bounds the replay after an unclean exit to a few blocks. It takes the blockchain lock as well as the list lock and runs off the block-handling path, matching `cleanup_proofs()`; `store()` itself is unchanged, so a clean shutdown behaves exactly as before.

Two things had to come with it:

**The periodic write must not serialise the long-term archive.** The archive grows without bound — 582MB and ~139k states on a node we measured — and the `ostringstream`/`str()`/`append` sequence transiently needs several times that. Putting it on a five-minute timer OOM-killed a fleet of 2GB containers, with the kernel reporting `anon-rss` exactly at the limit. `store()` now takes an `include_archive` parameter; only the periodic caller passes `false`, leaving the dirty flag set so the next full `store()` still writes it. Measured cost of the periodic write afterwards: **1.66 MB in 0.05s**.

**`blockchain_detached()` must clear the high-water mark.** It moves `m_state` backwards without touching `m_last_stored_height`, so the guard in `checkpoint_state()` suppressed every write until the chain climbed back past the old height — and a state written for an abandoned fork could survive at the same height and be reloaded on the next start.

## Also here

**Error messages that never identified anything.** `blockchain.cpp:379` used a fmt-style `{}` inside a stream-style `MFATAL`, so the fatal error that stops the daemon printed a literal `{}`. Separately, `crypto::hash` has a non-explicit `operator bool()` and no fmt formatter, so passing one to `fmt::format` silently selects the bool conversion:

```
Failed to verify block components for incoming block true at height 5703039
```

Seven call sites in `master_node_list.cpp` did this, including both checkpoint-verification failures. They now go through `tools::type_to_hex`. Three paths where `load()` gives up also returned `false` without logging; each sends the daemon into a full rescan, so an operator had no way to tell why a start was slow.

**Memory profile of the write.** The blob was built through three live copies — the archiver's buffer, the string `str()` returns, and a member string `append()` copied it into again — all held at once. The member (`cache_data_blob`) was worse than an extra copy: `clear()` does not release capacity, so after one archive write every node held the archive's full size in string capacity for the rest of the process's life. Each write now also logs its size and duration.

**Parallel transaction loading during the rescan** (`26bdba8dd`), mirroring how oxen-core loads blocks for the same scan. This one is offered for your judgement rather than asserted: it is correct as far as we can tell and has run without incident, but we were unable to produce a before/after measurement, because the checkpointing above largely removes the long rescans it would speed up. Drop it if you would rather not take an unmeasured change.

## Testing

Built and run on a 26-node mainnet master node fleet in 2GB containers.

- Unpatched daemons failed their replay and had to be restored from a snapshot after an unclean kill; patched ones restarted with their chain intact. Reproduced with `docker restart`, `docker kill` (no grace), a 2000-block `pop_blocks`, and an accidental SIGKILL of 24 nodes at once — 0 chain losses in every case.
- The archive-off-the-timer fix took the same fleet from 33 OOM kills in ~2 hours to 0.
- Currently soaking; no regressions so far.

One caveat worth stating: our nodes run a pruned blockchain, which is not officially supported for master nodes. The unclean-exit failure and the memory behaviour both reproduce independently of pruning, but our replay failures were observed on pruned nodes.