### PR TITLE
fix: reset cached height after blockchain recovery clear

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3692,7 +3692,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
           generate_genesis(b);
           m_blockchain.clear();
           m_blockchain.push_back(get_block_hash(b));
-          m_cached_height++;
+          m_cached_height = m_blockchain.size();
           short_chain_history.clear();
           get_short_chain_history(short_chain_history);
           fast_refresh(stop_height, blocks_start_height, short_chain_history, true);


### PR DESCRIPTION
Reset **`m_cached_height`** from the cleared blockchain size before validation checks, preventing stale pre-recovery height from being used if recovery exits early with an exception.